### PR TITLE
Add setting for handling send to owner default value

### DIFF
--- a/app/views/_issue_edit.erb
+++ b/app/views/_issue_edit.erb
@@ -1,1 +1,1 @@
-<%= check_box_tag 'send_to_owner', "true", false %> <%=h t('label_support_checkbox') %> (<%=h email %>)
+<%= check_box_tag 'send_to_owner', "true", send_to_owner_default %> <%=h t('label_support_checkbox') %> (<%=h email %>)

--- a/db/migrate/004_create_custom_field_for_send_to_owner_default.rb
+++ b/db/migrate/004_create_custom_field_for_send_to_owner_default.rb
@@ -1,0 +1,15 @@
+class CreateCustomFieldForSendToOwnerDefault < ActiveRecord::Migration
+  def self.up
+    c = CustomField.new(
+      :name => 'helpdesk-send-to-owner-default',
+      :editable => true,
+      :visible => false,          # do not show it on the project summary page
+      :field_format => 'bool')
+    c.type = 'ProjectCustomField' # cannot be set by mass assignement!
+    c.save
+  end
+
+  def self.down
+    CustomField.find_by_name('helpdesk-send-to-owner-default').delete
+  end
+end

--- a/lib/helpdesk_hooks.rb
+++ b/lib/helpdesk_hooks.rb
@@ -6,8 +6,11 @@ class HelpdeskHooks < Redmine::Hook::Listener
     c = CustomField.find_by_name('owner-email')
     owner_email = i.custom_value_for(c).try(:value)
     return if owner_email.blank?
+    p = i.project
+    s = CustomField.find_by_name('helpdesk-send-to-owner-default')
+    send_to_owner_default = p.custom_value_for(s).try(:value) if p.present? && s.present?
     action_view = ActionView::Base.new(File.dirname(__FILE__) + '/../app/views/')
-    action_view.render(:partial => "issue_edit", :locals => {:email => owner_email})
+    action_view.render(:partial => "issue_edit", :locals => {:email => owner_email, :send_to_owner_default => (send_to_owner_default.present? && send_to_owner_default || false)})
   end
   
   # fetch 'send_to_owner' param and set the value into journal.send_to_owner


### PR DESCRIPTION
Hi we added a setting to allow the configuration (on each project) of the default value of the send_to_owner checkbox. The change is backward compatible, if no setting is changed it default to false.
