### PR TITLE
English correction: 'send' should be 'sent'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,3 @@
 en:
   label_support_checkbox: "Send mail to supportclient"
-  email_was_send_to_supportclient: "This answer was send to the supportclient."
+  email_was_send_to_supportclient: "This answer was sent to the supportclient."


### PR DESCRIPTION
A slight English correction; "This answer was send to the supportclient" should be "This answer was sent to the supportclient."
