### PR TITLE
Fixed non-working helpdesk-send-to-owner-default checkbox

### DIFF
--- a/app/views/_issue_edit.erb
+++ b/app/views/_issue_edit.erb
@@ -1,1 +1,5 @@
-<%= check_box_tag 'send_to_owner', "true", send_to_owner_default %> <%=h t('label_support_checkbox') %> (<%=h email %>)
+<% if send_to_owner_default == "1" %>
+<%= check_box_tag 'send_to_owner', "true", true %> <%=h t('label_support_checkbox') %> (<%=h email %>)
+<% else %>
+<%= check_box_tag 'send_to_owner', "true" %> <%=h t('label_support_checkbox') %> (<%=h email %>)
+<% end %>


### PR DESCRIPTION
send_to_owner_default contains only "1" or "0" values in a character form and was always interpreted as true, so it caused checkbox to be always checked
