### PR TITLE
view_journal_bottom hook causing error

### DIFF
--- a/lib/helpdesk_hooks.rb
+++ b/lib/helpdesk_hooks.rb
@@ -27,7 +27,7 @@ class HelpdeskHooks < Redmine::Hook::Listener
   
   # add a history note on the journal
   def view_issues_history_journal_bottom(context={})
-    return if context[:journal].notes.length == 0
+    return if (context[:journal].notes || []).length == 0
     return unless context[:journal].send_to_owner == true
     i = Issue.find(context[:journal].journalized_id)
     c = CustomField.find_by_name('owner-email')


### PR DESCRIPTION
After installing the plugin, some issues stopped opening. Production log has the following error:

```
Completed 500 Internal Server Error in 1044.7ms

ActionView::Template::Error (undefined method `length' for nil:NilClass):
    16:     <%= render_notes(issue, journal, :reply_links => reply_links) unless journal.notes.blank? %>
    17:     </div>
    18:   </div>
    19:   <%= call_hook(:view_issues_history_journal_bottom, { :journal => journal }) %>
    20: <% end %>
    21:
    22: <% heads_for_wiki_formatter if User.current.allowed_to?(:edit_issue_notes, issue.project) || User.current.allowed_to?(:edit_own_issue_notes, issue.project) %>
  lib/redmine/hook.rb:61:in `block (2 levels) in call_hook'
  lib/redmine/hook.rb:61:in `each'
  lib/redmine/hook.rb:61:in `block in call_hook'
  lib/redmine/hook.rb:58:in `tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:158:in `call_hook'
  app/views/issues/_history.html.erb:19:in `block in _app_views_issues__history_html_erb___1517941129640751359_71094860'
```

This pull request fixes the issue (at least for our cases).
