### PR TITLE
Add support for non-anonymous supportclients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To use the helpdesk functionality you need to
 * add an email-footer into the custom_field 'helpdesk-email-footer' in the project configuration
 * add a sender email address into the custom_field 'helpdesk-sender-email' in the project configuration (optional)
 * make sure 'Issue added' and 'Issue updated' in the general redmine settings for email notifications are checked
+* add the permission 'Treat as supportclient' to all roles you want to be treated as supportclient (the permission is automatically added to the 'Anonymous' role)
+* disable standard notifications for non-anonymous supportclients to prevent their spamming (optional)
 * add a cronjob for creating issues from support emails
 
 ![project configuration sample](doc/project-settings.jpg "Per project configuration sample")
@@ -84,6 +86,7 @@ The latest version of this plugin is only compatible with Redmine 2.4.x.
 * [davidef](https://github.com/davidef) - Add setting for handling sent to owner default value
 * [Craig Gowing](https://github.com/craiggowing) - Redmine 2.4 compatibility
 * [Barbazul](https://github.com/barbazul) - Added reply-to header
+* [Orchitech Solutions](https://github.com/orchitech) - Added support for non-anonymous supportclients (sponsored by ISIC Global Office)
 
 ## License
 

--- a/db/migrate/005_add_treat_as_supportclient_to_anonymous.rb
+++ b/db/migrate/005_add_treat_as_supportclient_to_anonymous.rb
@@ -1,0 +1,11 @@
+class AddTreatAsSupportclientToAnonymous < ActiveRecord::Migration
+  def self.up
+    Role.find(2).add_permission!(:treat_user_as_supportclient)
+  end
+
+  def self.down
+    Role.find(:all).each do |r|
+      r.remove_permission!(:treat_user_as_supportclient)
+    end
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -11,4 +11,7 @@ Redmine::Plugin.register :redmine_helpdesk do
   description 'Redmine helpdesk plugin for netz98.de'
   version '0.0.11'
   requires_redmine :version_or_higher => '2.4.0'
+  project_module :issue_tracking do
+    permission :treat_user_as_supportclient, {}
+  end
 end

--- a/lib/mail_handler_patch.rb
+++ b/lib/mail_handler_patch.rb
@@ -15,8 +15,10 @@ module RedmineHelpdesk
       # an email request
       def dispatch_to_default_with_helpdesk
         issue = receive_issue
-        # add owner-email only if the email is comming from an AnonymousUser
-        if issue.author.class == AnonymousUser
+        roles = issue.author.roles_for_project(issue.project)
+        # add owner-email only if the author has assigned some role with
+        # permission treat_user_as_supportclient enabled
+        if roles.any? {|role| role.allowed_to?(:treat_user_as_supportclient) }
           sender_email = @email.from.first
           custom_field = CustomField.find_by_name('owner-email')
           custom_value = CustomValue.find(


### PR DESCRIPTION
Introduced the 'treat as supportclient' permission. If a user has this
permission, their incoming emails are expected to be support requests and
the 'owner-email' attribute is filled in the issue.
The  'treat as supportclient' is added to the 'Anonymous' role by default
(can be removed to avoid receiving support from unknown emails).
