### PR TITLE
Add issue matching based on standard MIME header references

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The latest version of this plugin is only compatible with Redmine 2.4.x.
 * [davidef](https://github.com/davidef) - Add setting for handling sent to owner default value
 * [Craig Gowing](https://github.com/craiggowing) - Redmine 2.4 compatibility
 * [Barbazul](https://github.com/barbazul) - Added reply-to header
+* [Orchitech Solutions](https://github.com/orchitech) - Added issue matching based on standard MIME header references
 
 ## License
 


### PR DESCRIPTION
Standard Redmine notifications encode the issue reference into the Message-Id
and References headers and the incoming email handling mechanism parses
it. This is now added to the helpdesk mailer to be consistent with the
standard Redmine mailer.
