### PR TITLE
Add customizable email footers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lightweight helpdesk plugin for redmine. Adds the email sender-address of an ano
 * Support for sending an email notification to the (anonymous user) supportclient on ticket creation
 * A standard first reply message can be send to the supportclient on ticket creation (optional, per project)
 * The email-footer for the email notification to the supportclient can be adjusted (optional, per project)
-* The email-footer can be customized by using the following placeholders: %USER_NAME%, %USER_LASTNAME%, %USER_EMAIL%, %USER_LOGIN%, %USER_CF_...% for all user custom fields
+* The email-footer can be customized by using the following placeholders: %USER_FIRST_NAME%, %USER_LAST_NAME%, %USER_EMAIL%, %USER_LOGIN%, %USER_CF_...% for all user custom fields
 * The sender email-address can be adjusted (optional, per project)
 * Internal communication is not send to the supportclient
 * The supportclient will get an email notification if the support checkbox on the journal is checked

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Lightweight helpdesk plugin for redmine. Adds the email sender-address of an ano
 * Support for sending an email notification to the (anonymous user) supportclient on ticket creation
 * A standard first reply message can be send to the supportclient on ticket creation (optional, per project)
 * The email-footer for the email notification to the supportclient can be adjusted (optional, per project)
+* The email-footer can be customized by using the following placeholders: %USER_NAME%, %USER_LASTNAME%, %USER_EMAIL%, %USER_LOGIN%, %USER_CF_...% for all user custom fields
 * The sender email-address can be adjusted (optional, per project)
 * Internal communication is not send to the supportclient
 * The supportclient will get an email notification if the support checkbox on the journal is checked
@@ -88,6 +89,7 @@ The latest version of this plugin is only compatible with Redmine 2.4.x. and 2.5
 * [Barbazul](https://github.com/barbazul) - Added reply-to header
 * [Orchitech Solutions](https://github.com/orchitech) - Added issue matching based on standard MIME header references
 * [Orchitech Solutions](https://github.com/orchitech) - Added support for non-anonymous supportclients (sponsored by ISIC Global Office)
+* [Orchitech Solutions](https://github.com/orchitech) - Added support for customizable email footers (sponsored by ISIC Global Office)
 
 ## License
 

--- a/db/migrate/006_append_footer_to_first_reply.rb
+++ b/db/migrate/006_append_footer_to_first_reply.rb
@@ -1,0 +1,20 @@
+class AppendFooterToFirstReply < ActiveRecord::Migration
+
+  # Appends helpdesk-email-footer to helpdesk-first-reply to ensure backward
+  # compatibility for updaters. See https://github.com/jfqd/redmine_helpdesk/issues/52
+  def self.up
+    first_reply_cf_id = CustomField.find_by_name('helpdesk-first-reply').id
+    footer_cf_id = CustomField.find_by_name('helpdesk-email-footer').id
+
+    CustomValue.where(:custom_field_id => first_reply_cf_id).each do |first_reply_cv|
+      if !first_reply_cv.value.nil?
+        first_reply_with_footer = first_reply_cv.value
+        first_reply_with_footer << "\n\n"
+        first_reply_with_footer << CustomValue.where("custom_field_id=? and customized_id=?", footer_cf_id, first_reply_cv.customized_id).first.value
+
+        CustomValue.update(first_reply_cv.id, :value => first_reply_with_footer)
+      end
+    end
+  end
+
+end

--- a/lib/helpdesk_mailer.rb
+++ b/lib/helpdesk_mailer.rb
@@ -33,6 +33,9 @@ class HelpdeskMailer < ActionMailer::Base
     f = CustomField.find_by_name('helpdesk-email-footer')
     reply  = p.nil? || r.nil? ? '' : p.custom_value_for(r).try(:value)
     footer = p.nil? || f.nil? ? '' : p.custom_value_for(f).try(:value)
+    if text.present?
+      footer = replace_footer_placeholders(footer, journal)
+    end
     # add any attachements
     if journal.present? && text.present?
       journal.details.each do |d|
@@ -70,7 +73,7 @@ class HelpdeskMailer < ActionMailer::Base
         :reply_to => sender.present? && sender || Setting.mail_from,
         :to       => recipient,
         :subject  => subject,
-        :body     => "#{reply}\n\n#{footer}".gsub("##issue-id##", issue.id.to_s),
+        :body     => "#{reply}".gsub("##issue-id##", issue.id.to_s),
         :date     => Time.zone.now
       )
     else
@@ -121,6 +124,23 @@ class HelpdeskMailer < ActionMailer::Base
   def references(object)
     @references_objects ||= []
     @references_objects << object
+  end
+
+  def replace_footer_placeholders(footer, journal)
+    placeholders = [
+      ["%USER_FIRST_NAME%", "#{journal.user.firstname}"],
+      ["%USER_LAST_NAME%", "#{journal.user.lastname}"],
+      ["%USER_EMAIL%", "#{journal.user.mail}"],
+      ["%USER_LOGIN%", "#{journal.user.login}"],
+    ]
+    CustomField.where(:type => 'UserCustomField').each do |user_cf|
+      cf_name = user_cf.name.upcase.gsub(' ', '_')
+      user_cf_cv = journal.user.custom_field_values.select { |cv| cv.custom_field.id == user_cf.id }.first.value
+      placeholders << ["%USER_CF_#{cf_name}%", user_cf_cv.nil? ? '' : user_cf_cv]
+    end
+
+    placeholders.each { |placeholder| footer = footer.gsub(placeholder[0], placeholder[1]) }
+    return footer
   end
 
 end


### PR DESCRIPTION
The email-footer can be customized by using the following placeholders: %USER_NAME%, %USER_LASTNAME%, %USER_EMAIL%, %USER_LOGIN%, %USER_CF_...% for all user custom fields.
Footers are no longer appended to the first replies. Upgrade to the new version appends the footer value to the first reply setting, so users don't need to configure this manually.
Fixes #52.