### PR TITLE
Add support for tracking supportclient email details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The latest version of this plugin is only compatible with Redmine 2.4.x. and 2.5
 * [Barbazul](https://github.com/barbazul) - Added reply-to header
 * [Orchitech Solutions](https://github.com/orchitech) - Added issue matching based on standard MIME header references
 * [Orchitech Solutions](https://github.com/orchitech) - Added support for non-anonymous supportclients (sponsored by ISIC Global Office)
+* [Orchitech Solutions](https://github.com/orchitech) - Added support for tracking email details (sponsored by ISIC Global Office)
 
 ## License
 

--- a/lib/mail_handler_patch.rb
+++ b/lib/mail_handler_patch.rb
@@ -20,6 +20,15 @@ module RedmineHelpdesk
         # permission treat_user_as_supportclient enabled
         if roles.any? {|role| role.allowed_to?(:treat_user_as_supportclient) }
           sender_email = @email.from.first
+          email_details = "From: " + @email[:from].formatted.first + "\n"
+          email_details << "To: " + @email[:to].formatted.join(', ') + "\n"
+          if !@email.cc.nil?
+            email_details << "Cc: " + @email[:cc].formatted.join(', ') + "\n"
+          end
+          email_details << "Date: " + @email[:date].to_s + "\n"
+          email_details = "<pre>\n" + Mail::Encodings.unquote_and_convert_to(email_details, 'utf-8') + "</pre>"
+          issue.description = email_details + issue.description
+          issue.save
           custom_field = CustomField.find_by_name('owner-email')
           custom_value = CustomValue.find(
             :first,


### PR DESCRIPTION
Shows extra details about incoming emails in preformatted text at the beginning of descriptions/comments.
Fixes #51.