### PR TITLE
Fill comment's autor in the specified place. Fixes #68.

### DIFF
--- a/lib/helpdesk_mailer.rb
+++ b/lib/helpdesk_mailer.rb
@@ -46,6 +46,12 @@ class HelpdeskMailer < ActionMailer::Base
         end
       end
     end
+    # footer now may contain ##author## template
+    author = ''
+    if journal.present?
+      author = journal.user.name
+    end
+    footer = footer.gsub('%%author%%', author)
     if @message_id_object
       headers[:message_id] = "<#{self.class.message_id_for(@message_id_object)}>"
     end


### PR DESCRIPTION
This adds the ability to replace a template '%%author%%' into the footer by comment's author.