### PR TITLE
Add support for reply separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If you prefer to run Redmine with JRuby make sure to use Redmine versions prior 
 * [Orchitech Solutions](https://github.com/orchitech) - Added support for non-anonymous supportclients (sponsored by ISIC Global Office)
 * [Orchitech Solutions](https://github.com/orchitech) - Added support for customizable email footers (sponsored by ISIC Global Office)
 * [Orchitech Solutions](https://github.com/orchitech) - Added support for tracking email details (sponsored by ISIC Global Office)
+* [Orchitech Solutions](https://github.com/orchitech) - Added support for reply separator (sponsored by ISIC Global Office)
 
 ## License
 

--- a/db/migrate/007_create_custom_field_for_reply_separator.rb
+++ b/db/migrate/007_create_custom_field_for_reply_separator.rb
@@ -1,0 +1,17 @@
+class CreateCustomFieldForReplySeparator < ActiveRecord::Migration
+  def self.up
+    c = CustomField.new(
+      :name => 'helpdesk-reply-separator',
+      :editable => true,
+      :visible => false,          # do not show it on the project summary page
+      :field_format => 'string',
+      :default_value => '--Reply above this line--')
+    c.type = 'ProjectCustomField'
+    c.save
+  end
+
+  def self.down
+    CustomField.find_by_name('helpdesk-reply-separator').delete
+  end
+end
+

--- a/lib/helpdesk_mailer.rb
+++ b/lib/helpdesk_mailer.rb
@@ -58,12 +58,18 @@ class HelpdeskMailer < ActionMailer::Base
       # sending out the journal note to the support client
       # or the first reply message
       t = text.present? ? "#{text}\n\n#{footer}" : reply
+      body = expand_macros(t, issue, journal)
+      f = CustomField.find_by_name('helpdesk-reply-separator')
+      reply_separator = issue.project.custom_value_for(f).try(:value)
+      if !reply_separator.blank?
+        body = reply_separator + "\n\n" + body
+      end
       mail(
         :from     => sender.present? && sender || Setting.mail_from,
         :reply_to => sender.present? && sender || Setting.mail_from,
         :to       => recipient,
         :subject  => subject,
-        :body     => expand_macros(t, issue, journal),
+        :body     => body,
         :date     => Time.zone.now
       )
     else

--- a/lib/mailer_patch.rb
+++ b/lib/mailer_patch.rb
@@ -44,7 +44,7 @@ module RedmineHelpdesk
         @users = to_users + cc_users + other_recipients
         f = CustomField.find_by_name('helpdesk-reply-separator')
         reply_separator = issue.project.custom_value_for(f).try(:value)
-        if !reply_separator.blank?
+        if !reply_separator.blank? and !journal.notes.nil?
           journal.notes = journal.notes.gsub(/#{reply_separator}.*/m, '')
           journal.save
         end

--- a/lib/mailer_patch.rb
+++ b/lib/mailer_patch.rb
@@ -42,6 +42,12 @@ module RedmineHelpdesk
         s << issue.subject
         @issue = issue
         @users = to_users + cc_users + other_recipients
+        f = CustomField.find_by_name('helpdesk-reply-separator')
+        reply_separator = issue.project.custom_value_for(f).try(:value)
+        if !reply_separator.blank?
+          journal.notes = journal.notes.gsub(/#{reply_separator}.*/m, '')
+          journal.save
+        end
         @journal = journal
         @journal_details = journal.visible_details(@users.first)
         @issue_url = url_for(:controller => 'issues', :action => 'show', :id => issue, :anchor => "change-#{journal.id}")


### PR DESCRIPTION
- adds reply separator at the beginning of e-mails "sent to supportclient"
- cuts the reply separator and everything below it (removes the quoted text from the emails received from supportclients)
