### PR TITLE
#4519: fixed email visibility

### DIFF
--- a/app/views/_issue_edit.erb
+++ b/app/views/_issue_edit.erb
@@ -1,1 +1,1 @@
-<%= check_box_tag('send_to_owner', "true", (send_to_owner_default == "1")) %> <%=h t('label_support_checkbox') %> (<%=h email %>)
+<%= check_box_tag('send_to_owner', "true", (send_to_owner_default == "1")) %> <%=h t('label_support_checkbox') %><% if email_visible %> (<%=h email %>)<% end %>

--- a/lib/helpdesk_hooks.rb
+++ b/lib/helpdesk_hooks.rb
@@ -14,6 +14,7 @@ class HelpdeskHooks < Redmine::Hook::Listener
       :partial => "issue_edit",
       :locals => {
         :email => owner_email,
+        :email_visible => c.visible_by?(p),
         :send_to_owner_default => (send_to_owner_default.present? && send_to_owner_default || false)
       }
     )


### PR DESCRIPTION
Error: The value of the custom field owner_email ist visible even if the role permission denies this.

![2015-11-26_184246-2](https://cloud.githubusercontent.com/assets/898174/11439872/9cffd112-94fe-11e5-91f6-d578bac462fc.png)

This fix checks the visibility and the value of owner_email is only displayed if the custom field is visible.