### PR TITLE
Add support for tracking supportclient email details in comments

### DIFF
--- a/db/migrate/009_create_custom_owner_name_field.rb
+++ b/db/migrate/009_create_custom_owner_name_field.rb
@@ -1,0 +1,19 @@
+class CreateCustomOwnerNameField < ActiveRecord::Migration
+  def self.up
+    c = CustomField.new(
+      :name => 'owner-name',
+      :editable => true,
+      :field_format => 'string')
+    c.type = 'IssueCustomField' # cannot be set by mass assignement!
+    c.save
+    Tracker.all.each do |t|
+      execute "INSERT INTO custom_fields_trackers (custom_field_id,tracker_id) VALUES (#{c.id},#{t.id})"
+    end
+  end
+
+  def self.down
+    c = CustomField.find_by_name('owner-name')
+    execute "DELETE FROM custom_fields_trackers WHERE custom_field_id=#{c.id}"
+    c.delete
+  end
+end

--- a/lib/mail_handler_patch.rb
+++ b/lib/mail_handler_patch.rb
@@ -29,13 +29,17 @@ module RedmineHelpdesk
             first
           custom_value.value = sender_email
           custom_value.save(:validate => false) # skip validation!
-          address = Mail::Address.new(@email[:from].formatted.first)
           custom_field = CustomField.find_by_name('owner-name')
-          custom_value = CustomValue.where(
-            "customized_id = ? AND custom_field_id = ?", issue.id, custom_field.id).
-            first
-          custom_value.value =  address.display_name
-          custom_value.save(:validate => false) # skip validation!
+          unless custom_field.nil?
+            custom_value = CustomValue.where(
+              "customized_id = ? AND custom_field_id = ?", issue.id, custom_field.id).
+              first
+            unless custom_value.nil?
+              address = Mail::Address.new(@email[:from].formatted.first)
+              custom_value.value = address.display_name
+              custom_value.save(:validate => false) # skip validation!
+            end
+          end
           # regular email sending to known users is done
           # on the first issue.save. So we need to send
           # the notification email to the supportclient

--- a/lib/mail_handler_patch.rb
+++ b/lib/mail_handler_patch.rb
@@ -5,6 +5,7 @@ module RedmineHelpdesk
 
       base.class_eval do
         alias_method_chain :dispatch_to_default, :helpdesk
+        alias_method_chain :receive_issue_reply, :helpdesk
       end
     end
 
@@ -20,20 +21,20 @@ module RedmineHelpdesk
         # permission treat_user_as_supportclient enabled
         if roles.any? {|role| role.allowed_to?(:treat_user_as_supportclient) }
           sender_email = @email.from.first
-          email_details = "From: " + @email[:from].formatted.first + "\n"
-          email_details << "To: " + @email[:to].formatted.join(', ') + "\n"
-          if !@email.cc.nil?
-            email_details << "Cc: " + @email[:cc].formatted.join(', ') + "\n"
-          end
-          email_details << "Date: " + @email[:date].to_s + "\n"
-          email_details = "<pre>\n" + Mail::Encodings.unquote_and_convert_to(email_details, 'utf-8') + "</pre>"
-          issue.description = email_details + issue.description
+          issue.description = email_details(@email) + issue.description
           issue.save
           custom_field = CustomField.find_by_name('owner-email')
           custom_value = CustomValue.where(
             "customized_id = ? AND custom_field_id = ?", issue.id, custom_field.id).
             first
           custom_value.value = sender_email
+          custom_value.save(:validate => false) # skip validation!
+          address = Mail::Address.new(@email[:from].formatted.first)
+          custom_field = CustomField.find_by_name('owner-name')
+          custom_value = CustomValue.where(
+            "customized_id = ? AND custom_field_id = ?", issue.id, custom_field.id).
+            first
+          custom_value.value =  address.display_name
           custom_value.save(:validate => false) # skip validation!
           # regular email sending to known users is done
           # on the first issue.save. So we need to send
@@ -61,6 +62,26 @@ module RedmineHelpdesk
                                :content_type => attachment.mime_type)
           end
         end
+      end
+
+      def email_details(email)
+        details = "From: " + @email[:from].formatted.first + "\n"
+        details << "To: " + @email[:to].formatted.join(', ') + "\n"
+        if !@email.cc.nil?
+          details << "Cc: " + @email[:cc].formatted.join(', ') + "\n"
+        end
+        details << "Date: " + @email[:date].to_s + "\n"
+        "<pre>\n" + Mail::Encodings.unquote_and_convert_to(details, 'utf-8') + "</pre>"
+      end
+
+      # Overrides the receive_issue_reply method to add
+      # email details to the journal note
+      def receive_issue_reply_with_helpdesk(issue_id, from_journal=nil)
+        receive_issue_reply_without_helpdesk(issue_id, from_journal=nil)
+        issue = Issue.find_by_id(issue_id)
+        last_journal = Journal.find(issue.last_journal_id)
+        last_journal.notes = email_details(@email) + last_journal.notes
+        last_journal.save
       end
 
     end # module InstanceMethods


### PR DESCRIPTION
Email details are currently added only to issue description (see #56). This adds the email details to issue comments as well. Also, we have added new optional custom field for tracking owner name.