### PR TITLE
inline image support

### DIFF
--- a/app/views/helpdesk/note_edit.html.erb
+++ b/app/views/helpdesk/note_edit.html.erb
@@ -1,0 +1,1 @@
+<%= @text.html_safe %>

--- a/app/views/helpdesk/note_edit.text.erb
+++ b/app/views/helpdesk/note_edit.text.erb
@@ -1,0 +1,1 @@
+<%= ActionView::Base.full_sanitizer.sanitize(@text) %>


### PR DESCRIPTION
Hello I have added support to show inline images in the outgoing email (the images are shown alongside the text). IE: when you modify an issue and you paste an image using the plugin redmine_image_clipboard_paste.

I found it very useful so I wanted yo share.

Regards,

