### PR TITLE
Sets To header optional. Not all the emails have this header. If not, it raises  an exception.

### DIFF
--- a/lib/mail_handler_patch.rb
+++ b/lib/mail_handler_patch.rb
@@ -121,7 +121,7 @@ module RedmineHelpdesk
 
       def email_details
         details =  "From: " + @email[:from].formatted.first + "\n"
-        details << "To:   " + @email[:to].formatted.join(', ') + "\n"
+        details << "To:   " + @email[:to].formatted.join(', ') + "\n" if !@email.to.nil?
         details << "Cc:   " + @email[:cc].formatted.join(', ') + "\n" if !@email.cc.nil?
         details << "Date: " + @email[:date].to_s + "\n"
         "<pre>\n" + Mail::Encodings.unquote_and_convert_to(details, 'utf-8') + "</pre>\n\n"


### PR DESCRIPTION
It the message has not a **To** header it raises an 

` ERROR -- : MailHandler: an unexpected error occurred when receiving email: undefined method `formatted' for nil:NilClass
`

The **To header** is not mandatory in IMAP. Some clientes don't add it or maybe the message is sent trough a bcc header for privacity issues. 