### PR TITLE
Update helpdesk mail handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.21
+---
+* Make plugin compatibility with Redmine 6.1.x
+* Fix Email-Notifications
+
 0.0.20
 ---
 * Make plugin compatibility with Redmine 5.0.x

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Please note that forwarding emails with **rdm-mailhandler.rb** is currently **no
 
 ## Compatibility
 
-The latest version of this plugin is only compatible with Redmine 5.0, 5.1.
+The latest version of this plugin is compatible with Redmine 5.0, 5.1., 6.1.
 
 * A version for Redmine 4.2.x is tagged with [v4.2](https://github.com/jfqd/redmine_helpdesk/releases/tag/v4.2 "plugin version for Redmine 4.2.x") and available for [download on github](https://github.com/jfqd/redmine_helpdesk/archive/v4.2.zip "download plugin for Redmine 4.2.x").
 * A version for Redmine 4.0.x is tagged with [v4.0](https://github.com/jfqd/redmine_helpdesk/releases/tag/v4.0 "plugin version for Redmine 4.0.x") and available for [download on github](https://github.com/jfqd/redmine_helpdesk/archive/v4.0.zip "download plugin for Redmine 4.0.x").

--- a/init.rb
+++ b/init.rb
@@ -10,8 +10,8 @@ Redmine::Plugin.register :redmine_helpdesk do
   name 'Redmine helpdesk plugin'
   author 'Stefan Husch'
   description 'Redmine helpdesk plugin'
-  version '0.0.20'
-  requires_redmine :version_or_higher => '5.0.0'
+  version '0.0.21'
+  requires_redmine :version_or_higher => '6.1.0'
   project_module :issue_tracking do
     permission :treat_user_as_supportclient, {}
   end

--- a/lib/redmine_helpdesk/mail_handler_patch.rb
+++ b/lib/redmine_helpdesk/mail_handler_patch.rb
@@ -1,101 +1,96 @@
 module RedmineHelpdesk
   module MailHandlerPatch
-    def self.included(base) # :nodoc:
+    def self.included(base)
       base.send(:include, InstanceMethods)
 
       base.class_eval do
         alias_method :dispatch_to_default_without_helpdesk, :dispatch_to_default
         alias_method :dispatch_to_default, :dispatch_to_default_with_helpdesk
-        # needed for reopening a closed issue
-        alias_method :receive_issue_reply_without_helpdesk, :receive_issue_reply
-        alias_method :receive_issue_reply, :receive_issue_reply_with_helpdesk
+
+        unless method_defined?(:receive_issue_reply_without_helpdesk) ||
+               private_method_defined?(:receive_issue_reply_without_helpdesk)
+          alias_method :receive_issue_reply_without_helpdesk, :receive_issue_reply
+          alias_method :receive_issue_reply, :receive_issue_reply_with_helpdesk
+
+          private :receive_issue_reply, :receive_issue_reply_without_helpdesk
+        end
       end
     end
 
     module InstanceMethods
       private
-      # Overrides the dispatch_to_default method to
-      # set the owner-email of a new issue created by
-      # an email request
+
       def dispatch_to_default_with_helpdesk
         issue = receive_issue
-        issue.reload # prevent ActiveRecord::StaleObjectError
+        issue.reload
+
         roles = if issue.author.class == AnonymousUser
-          Role.where(builtin: issue.author.id)
-        else
-          issue.author.roles_for_project(issue.project)
-        end
-        # add owner-email only if the author has assigned some role with
-        # permission treat_user_as_supportclient enabled
-        if issue.author.type.eql?("AnonymousUser") || roles.any? {|role| role.allowed_to?(:treat_user_as_supportclient) }
+                  Role.where(builtin: issue.author.id)
+                else
+                  issue.author.roles_for_project(issue.project)
+                end
+
+        if issue.author.type.eql?("AnonymousUser") || roles.any? { |role| role.allowed_to?(:treat_user_as_supportclient) }
           sender_email = @email.from.first
-          
-          # any cc handling needed?
-          custom_value = custom_field_value(issue.project,'cc-handling')
-          if (!@email.cc.nil?) && (custom_value.value == '1')
+
+          cc_handling_value = custom_field_value(issue.project, 'cc-handling')
+          if @email.cc.present? && cc_handling_value&.value == '1'
             carbon_copy = @email[:cc].formatted.join(', ')
-            custom_value = custom_field_value(issue,'copy-to')
-            custom_value.value = carbon_copy
-            custom_value.save( validate: false ) # skip validation!
+            copy_to_value = custom_field_value(issue, 'copy-to')
+            if copy_to_value
+              copy_to_value.value = carbon_copy
+              copy_to_value.save(validate: false)
+            end
           else
             carbon_copy = nil
           end
-          
-          issue.description = email_details + issue.description
-          issue.save( validate: false ) # skip validation!
-          
-          custom_value = custom_field_value(issue,'owner-email')
-          if custom_value.value.to_s.strip.empty?
-            custom_value.value = sender_email
-            custom_value.save( validate: false ) # skip validation!
-          else
-            # Email owner field was already set by some preprocess hooks.
-            # So now we need to send message to another recepient.
-            sender_email = custom_value.value.to_s.strip
+
+          issue.description = email_details + issue.description.to_s
+          issue.save(validate: false)
+
+          owner_email_value = custom_field_value(issue, 'owner-email')
+          if owner_email_value && owner_email_value.value.to_s.strip.empty?
+            owner_email_value.value = sender_email
+            owner_email_value.save(validate: false)
+          elsif owner_email_value
+            sender_email = owner_email_value.value.to_s.strip
           end
-          
-          # regular email sending to known users is done
-          # on the first issue.save. So we need to send
-          # the notification email to the supportclient
-          # on our own.
+
           HelpdeskMailer.email_to_supportclient(
-            issue, {
-              recipient:   sender_email,
+            issue,
+            {
+              recipient: sender_email,
               carbon_copy: carbon_copy
             }
-          ).deliver
+          ).deliver_now
         end
+
         after_dispatch_to_default_hook issue
-        return issue
+        issue
       end
 
-      # let other plugins the chance to override this
-      # method to hook into dispatch_to_default
       def after_dispatch_to_default_hook(issue)
       end
 
-      # Fix an issue with email.has_attachments?
       def add_attachments(obj)
-         if !email.attachments.nil? && email.attachments.size > 0
-           email.attachments.each do |attachment|
-             obj.attachments << Attachment.create(
-               container:    obj,
-               file:         attachment.decoded,
-               filename:     attachment.filename,
-               author:       user,
-               content_type: attachment.mime_type
-             )
+        if !email.attachments.nil? && email.attachments.size > 0
+          email.attachments.each do |attachment|
+            obj.attachments << Attachment.create(
+              container: obj,
+              file: attachment.decoded,
+              filename: attachment.filename,
+              author: user,
+              content_type: attachment.mime_type
+            )
           end
         end
       end
 
-      # Overrides the receive_issue_reply method
-      def receive_issue_reply_with_helpdesk(issue_id, from_journal=nil)
+      def receive_issue_reply_with_helpdesk(issue_id, from_journal = nil)
         issue = Issue.find_by_id(issue_id)
         return unless issue
 
-        # reopening a closed issues by email
-        custom_value = custom_field_value(issue.project,'reopen-issues-with')
+        custom_value = custom_field_value(issue.project, 'reopen-issues-with')
         if issue.closed? && custom_value.present? && custom_value.value.present?
           status_id = IssueStatus.where("name = ?", custom_value.value).try(:first).try(:id)
           unless status_id.nil?
@@ -104,35 +99,64 @@ module RedmineHelpdesk
           end
         end
 
-        # call original method
         receive_issue_reply_without_helpdesk(issue_id, from_journal)
 
-        # store email-details before each note
+        issue.reload
         last_journal = Journal.find(issue.last_journal_id)
-        last_journal.notes = email_details + last_journal.notes
-        last_journal.save
+        last_journal.notes = email_details + last_journal.notes.to_s
+        last_journal.save(validate: false)
 
-        return last_journal
+        send_supportclient_notification(issue, last_journal)
+
+        last_journal
       end
-      
-      def custom_field_value(issue,name)
+
+      def send_supportclient_notification(issue, journal)
+        return unless journal.respond_to?(:send_to_owner) && journal.send_to_owner
+
+        owner_cf = CustomField.find_by_name('owner-email')
+        return unless owner_cf
+
+        owner_email = issue.custom_value_for(owner_cf).try(:value).to_s.strip
+        return if owner_email.blank?
+
+        cc_users = nil
+
+        begin
+          copy_to_cf = CustomField.find_by_name('copy-to')
+          if copy_to_cf
+            copy_to_value = issue.custom_value_for(copy_to_cf).try(:value).to_s
+            cc_users = copy_to_value.split(',').map(&:strip).reject(&:blank?) if copy_to_value.present?
+          end
+        rescue => e
+          Rails.logger.error "Helpdesk owner mail: CC resolution failed: #{e.message}"
+        end
+
+        Mailer.helpdesk_issue_edit_to_owner(issue, journal, owner_email, cc_users).deliver_now
+      rescue => e
+        Rails.logger.error "Helpdesk owner mail failed for issue ##{issue.id}: #{e.class}: #{e.message}"
+      end
+
+      def custom_field_value(record, name)
         custom_field = CustomField.find_by_name(name)
+        return nil unless custom_field
+
         CustomValue.where(
-          "customized_id = ? AND custom_field_id = ?", issue.id, custom_field.id
+          customized_type: record.class.name,
+          customized_id: record.id,
+          custom_field_id: custom_field.id
         ).first
       end
 
       def email_details
-        details =  "From: " + @email[:from].formatted.first + "\n"
+        details = "From: " + @email[:from].formatted.first + "\n"
         details << "To:   " + @email[:to].formatted.join(', ') + "\n" if !@email.to.nil?
         details << "Cc:   " + @email[:cc].formatted.join(', ') + "\n" if !@email.cc.nil?
         details << "Date: " + @email[:date].to_s + "\n"
         "<pre>\n" + Mail::Encodings.unquote_and_convert_to(details, 'utf-8') + "</pre>\n\n"
       end
+    end
+  end
+end
 
-    end # module InstanceMethods
-  end # module MailHandlerPatch
-end # module RedmineHelpdesk
-
-# Add module to MailHandler class
 MailHandler.send(:include, ::RedmineHelpdesk::MailHandlerPatch)

--- a/lib/redmine_helpdesk/mail_handler_patch.rb
+++ b/lib/redmine_helpdesk/mail_handler_patch.rb
@@ -1,12 +1,12 @@
 module RedmineHelpdesk
   module MailHandlerPatch
-    def self.included(base)
+    def self.included(base) # :nodoc:
       base.send(:include, InstanceMethods)
 
       base.class_eval do
         alias_method :dispatch_to_default_without_helpdesk, :dispatch_to_default
         alias_method :dispatch_to_default, :dispatch_to_default_with_helpdesk
-
+        # needed for reopening a closed issue
         unless method_defined?(:receive_issue_reply_without_helpdesk) ||
                private_method_defined?(:receive_issue_reply_without_helpdesk)
           alias_method :receive_issue_reply_without_helpdesk, :receive_issue_reply
@@ -19,43 +19,52 @@ module RedmineHelpdesk
 
     module InstanceMethods
       private
-
+      # Overrides the dispatch_to_default method to
+      # set the owner-email of a new issue created by
+      # an email request
       def dispatch_to_default_with_helpdesk
         issue = receive_issue
-        issue.reload
-
+        issue.reload # prevent ActiveRecord::StaleObjectError
         roles = if issue.author.class == AnonymousUser
                   Role.where(builtin: issue.author.id)
                 else
                   issue.author.roles_for_project(issue.project)
                 end
-
+        # add owner-email only if the author has assigned some role with
+        # permission treat_user_as_supportclient enabled
         if issue.author.type.eql?("AnonymousUser") || roles.any? { |role| role.allowed_to?(:treat_user_as_supportclient) }
           sender_email = @email.from.first
 
+          # any cc handling needed?
           cc_handling_value = custom_field_value(issue.project, 'cc-handling')
           if @email.cc.present? && cc_handling_value&.value == '1'
             carbon_copy = @email[:cc].formatted.join(', ')
             copy_to_value = custom_field_value(issue, 'copy-to')
             if copy_to_value
               copy_to_value.value = carbon_copy
-              copy_to_value.save(validate: false)
+              copy_to_value.save(validate: false) # skip validation!
             end
           else
             carbon_copy = nil
           end
 
           issue.description = email_details + issue.description.to_s
-          issue.save(validate: false)
+          issue.save(validate: false) # skip validation!
 
           owner_email_value = custom_field_value(issue, 'owner-email')
           if owner_email_value && owner_email_value.value.to_s.strip.empty?
             owner_email_value.value = sender_email
             owner_email_value.save(validate: false)
           elsif owner_email_value
+            # Email owner field was already set by some preprocess hooks.
+            # So now we need to send message to another recepient.
             sender_email = owner_email_value.value.to_s.strip
           end
 
+          # regular email sending to known users is done
+          # on the first issue.save. So we need to send
+          # the notification email to the supportclient
+          # on our own.
           HelpdeskMailer.email_to_supportclient(
             issue,
             {
@@ -64,14 +73,16 @@ module RedmineHelpdesk
             }
           ).deliver_now
         end
-
         after_dispatch_to_default_hook issue
         issue
       end
 
+      # let other plugins the chance to override this
+      # method to hook into dispatch_to_default
       def after_dispatch_to_default_hook(issue)
       end
 
+      # Fix an issue with email.has_attachments?
       def add_attachments(obj)
         if !email.attachments.nil? && email.attachments.size > 0
           email.attachments.each do |attachment|
@@ -86,11 +97,13 @@ module RedmineHelpdesk
         end
       end
 
-      def receive_issue_reply_with_helpdesk(issue_id, from_journal = nil)
+      # Overrides the receive_issue_reply method
+      def receive_issue_reply_with_helpdesk(issue_id, from_journal=nil)
         issue = Issue.find_by_id(issue_id)
         return unless issue
 
-        custom_value = custom_field_value(issue.project, 'reopen-issues-with')
+        # reopening a closed issues by email
+        custom_value = custom_field_value(issue.project,'reopen-issues-with')
         if issue.closed? && custom_value.present? && custom_value.value.present?
           status_id = IssueStatus.where("name = ?", custom_value.value).try(:first).try(:id)
           unless status_id.nil?
@@ -99,9 +112,11 @@ module RedmineHelpdesk
           end
         end
 
+        # call original method
         receive_issue_reply_without_helpdesk(issue_id, from_journal)
 
         issue.reload
+        # store email-details before each note
         last_journal = Journal.find(issue.last_journal_id)
         last_journal.notes = email_details + last_journal.notes.to_s
         last_journal.save(validate: false)
@@ -155,8 +170,10 @@ module RedmineHelpdesk
         details << "Date: " + @email[:date].to_s + "\n"
         "<pre>\n" + Mail::Encodings.unquote_and_convert_to(details, 'utf-8') + "</pre>\n\n"
       end
-    end
-  end
-end
 
+    end # module InstanceMethods
+  end # module MailHandlerPatch
+end # module RedmineHelpdesk
+
+# Add module to MailHandler class
 MailHandler.send(:include, ::RedmineHelpdesk::MailHandlerPatch)

--- a/lib/redmine_helpdesk/mailer_patch.rb
+++ b/lib/redmine_helpdesk/mailer_patch.rb
@@ -1,87 +1,58 @@
 module RedmineHelpdesk
   module MailerPatch
-    def self.included(base) # :nodoc:
+    def self.included(base)
       base.send(:include, InstanceMethods)
-      
-      base.class_eval do
-        alias_method :issue_edit_without_helpdesk, :issue_edit
-        alias_method :issue_edit, :issue_edit_with_helpdesk
-      end
     end
 
     module InstanceMethods
-      # Overrides the issue_edit method which is only
-      # be called on existing tickets. We will add the
-      # owner-email to the recipients only if no email-
-      # footer text is available.
-      def issue_edit_with_helpdesk(user, journal)
-        issue = journal.journalized
+      def helpdesk_issue_edit_to_owner(issue, journal, owner_email, cc_users = nil)
         redmine_headers 'Project' => issue.project.identifier,
                         'Issue-Id' => issue.id,
                         'Issue-Author' => issue.author.login,
                         'Issue-Tracker' => issue.tracker
         redmine_headers 'Issue-Assignee' => issue.assigned_to.login if issue.assigned_to
+
         message_id journal
         references issue
+
         @author = journal.user
 
-        # process reply-separator
-        f = CustomField.find_by_name('helpdesk-reply-separator')
-        reply_separator = issue.project.custom_value_for(f).try(:value)
-        if !reply_separator.blank? and !journal.notes.nil?
-          journal.notes = journal.notes.gsub(/#{reply_separator}.*/m, '')
-          journal.save(:validate => false)
-        end
-
-        # add owner-email to the recipients
-        alternative_user = nil
         begin
-          if journal.send_to_owner == true
-            f = CustomField.find_by_name('helpdesk-email-footer')
-            p = issue.project
-            owner_email = issue.custom_value_for( CustomField.find_by_name('owner-email') ).value
-            if !owner_email.blank? && !f.nil? && !p.nil? && p.custom_value_for(f).try(:value).blank?
-              alternative_user = owner_email
-            end
+          f = CustomField.find_by_name('helpdesk-reply-separator')
+          reply_separator = issue.project.custom_value_for(f).try(:value)
+          if reply_separator.present? && journal.notes.present?
+            @journal = journal.dup
+            @journal.notes = journal.notes.gsub(/#{Regexp.escape(reply_separator)}.*/m, '')
+          else
+            @journal = journal
           end
-        rescue Exception => e
-          Rails.logger.error "Error while adding owner-email to recipients of email notification: \"#{e.message}\"."
-        end
-
-        # any cc handling needed?
-        cc_users = nil
-        begin
-          # any cc handling needed?
-          if alternative_user.present?
-            custom_field = CustomField.find_by_name('cc-handling')
-            custom_value = CustomValue.where(
-              "customized_id = ? AND custom_field_id = ?", issue.project.id, custom_field.id
-            ).first
-            cc_users = custom_value.value.split(',').map(&:strip) if custom_value.value.present?
-          end
-        rescue Exception => e
-          Rails.logger.error "Error while adding cc-users to recipients of email notification: \"#{e.message}\"."
+        rescue => e
+          Rails.logger.error "Helpdesk owner mail: reply separator processing failed: #{e.message}"
+          @journal = journal
         end
 
         s = "[#{issue.project.name} - #{issue.tracker.name} ##{issue.id}] "
         s += "(#{issue.status.name}) " if journal.new_value_for('status_id') && Setting.show_status_changes_in_mail_subject?
         s += issue.subject
-        u = (alternative_user.present? ? alternative_user : user)
+
         @issue = issue
-        @user = u
-        @journal = journal
+        @user = journal.user
         @journal_details = journal.visible_details
-        @issue_url = url_for(:controller => 'issues', :action => 'show', :id => issue, :anchor => "change-#{journal.id}")
+        @issue_url = url_for(
+          controller: 'issues',
+          action: 'show',
+          id: issue,
+          anchor: "change-#{journal.id}"
+        )
+
         mail(
-          :to => u,
-          :cc => cc_users,
-          :subject => s
+          to: owner_email,
+          cc: Array(cc_users).flatten.compact.reject(&:blank?).presence,
+          subject: s
         )
       end
-      
-    end # module InstanceMethods
-  end # module MailerPatch
-end # module RedmineHelpdesk
+    end
+  end
+end
 
-# Add module to Mailer class
 Mailer.send(:include, ::RedmineHelpdesk::MailerPatch)

--- a/lib/redmine_helpdesk/mailer_patch.rb
+++ b/lib/redmine_helpdesk/mailer_patch.rb
@@ -1,10 +1,14 @@
 module RedmineHelpdesk
   module MailerPatch
-    def self.included(base)
+    def self.included(base) # :nodoc:
       base.send(:include, InstanceMethods)
     end
 
     module InstanceMethods
+      # Extends the issue_edit method which is only
+      # be called on existing tickets. We will add the
+      # owner-email to the recipients only if no email-
+      # footer text is available.
       def helpdesk_issue_edit_to_owner(issue, journal, owner_email, cc_users = nil)
         redmine_headers 'Project' => issue.project.identifier,
                         'Issue-Id' => issue.id,
@@ -16,7 +20,7 @@ module RedmineHelpdesk
         references issue
 
         @author = journal.user
-
+        # process reply-separator
         begin
           f = CustomField.find_by_name('helpdesk-reply-separator')
           reply_separator = issue.project.custom_value_for(f).try(:value)
@@ -51,8 +55,9 @@ module RedmineHelpdesk
           subject: s
         )
       end
-    end
-  end
-end
+    end # module InstanceMethods
+  end # module MailerPatch
+end # module RedmineHelpdesk
 
+# Add module to Mailer class
 Mailer.send(:include, ::RedmineHelpdesk::MailerPatch)


### PR DESCRIPTION
The mail handler was updated so that it no longer overrides the existing mail handling logic. Instead, it extends the existing mail handler with the plugin-specific functionality.

Tested (smtp) with this docker configuration: 

Environment:
  Redmine version                6.1.2.stable
  Ruby version                     3.4.9-p82 (2026-03-11) [x86_64-linux]
  Rails version                     7.2.3
  Environment                    production
  Database adapter            Mysql2
  Mailer queue                   ActiveJob::QueueAdapters::SidekiqAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Default
SCM:
  Subversion                     1.14.5
  Mercurial                        7.0.1
  Bazaar                            3.3.11
  Git                                  2.47.3
  Filesystem                     
Redmine plugins:
  redmine_dashboard              2.16.0
  redmine_dmsf                       5.0.1
  redmine_helpdesk                0.0.21
  redmine_time_logging_app  1.3
